### PR TITLE
Add no-sanbox and disable-extensions options

### DIFF
--- a/lib/crawler/support/capybara.rb
+++ b/lib/crawler/support/capybara.rb
@@ -15,6 +15,8 @@ module Capybara
       options.add_preference(:browser, set_download_behavior: {behavior: 'allow'})
       options.add_argument('--headless')
       options.add_argument('--disable-gpu')
+      options.add_argument('--disable-extensions')
+      options.add_argument("--no-sandbox")
       options.add_argument("--window-size=#{window_width},#{window_height}")
 
       driver = ::Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)


### PR DESCRIPTION
Add no-sanbox and disable-extensions options for work from docker container.

link on docker issue:
https://github.com/RobCherry/docker-chromedriver/issues/15